### PR TITLE
CMake: the install rule does not depend on all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ script:
   # build
   - mkdir build && cd build
   - cmake .. -DCMAKE_INSTALL_PREFIX=`pwd`/../install -DSEQUENCEPARSER_PYTHON_VERSION=2.7
-  - make $J install
+  - make $J
+  - make install
 
   # tests
   - cd ${TRAVIS_BUILD_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ add_definitions(-DSEQUENCEPARSER_VERSION_MICRO=${SEQUENCEPARSER_VERSION_MICRO})
 # Diplay commands being ran by CMake
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
+# The install rule does not depend on all, i.e. everything will not be built before installing
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE)
+
 # CPP flags on debug / release mode
 if(MSVC)
 	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,8 +33,8 @@ install(
 	PATTERN "*.hpp"
 	PATTERN "*.i"
 )
-install(TARGETS sequenceparser-static DESTINATION lib/)
-install(TARGETS sequenceparser-shared DESTINATION lib/)
+install(TARGETS sequenceparser-static DESTINATION lib/ OPTIONAL)
+install(TARGETS sequenceparser-shared DESTINATION lib/ OPTIONAL)
 
 ### SWIG
 find_package(SWIG)
@@ -78,9 +78,10 @@ if(SWIG_FOUND)
 		install(
 			FILES ${SEQUENCEPARSER_PYTHON_BINDING_FILE} ${SEQUENCEPARSER_PYTHON_INIT_FILE}
 			DESTINATION ${SEQUENCEPARSER_PYTHON_MODULE_OUTPUT_DIR}
+			OPTIONAL
 		)
 		# Install python lib and __init__.py files
-		install(TARGETS ${SWIG_MODULE_sequenceparser-py_REAL_NAME} DESTINATION "lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pySequenceParser/")
+		install(TARGETS ${SWIG_MODULE_sequenceparser-py_REAL_NAME} DESTINATION "lib/python${PYTHONLIBS_VERSION_STRING}/site-packages/pySequenceParser/" OPTIONAL)
 		install(CODE "file(WRITE ${CMAKE_INSTALL_PREFIX}/${SEQUENCEPARSER_PYTHON_MODULE_OUTPUT_DIR}/__init__.py)")
 	else()
 		message("PYTHON not found, will not build python binding.")
@@ -128,8 +129,8 @@ if(SWIG_FOUND)
 		)
 
 		# Install java lib and jar files
-		install(TARGETS ${SWIG_MODULE_sequenceparser-java_REAL_NAME} DESTINATION "lib/java")
-		install(FILES ${SEQUENCEPARSER_JAR_PATH}/${SEQUENCEPARSER_JAR_NAME} DESTINATION "share/java/")
+		install(TARGETS ${SWIG_MODULE_sequenceparser-java_REAL_NAME} DESTINATION "lib/java" OPTIONAL)
+		install(FILES ${SEQUENCEPARSER_JAR_PATH}/${SEQUENCEPARSER_JAR_NAME} DESTINATION "share/java/" OPTIONAL)
 	else()
 		message("JAVA not found, will not build java binding.")
 	endif()


### PR DESCRIPTION
* "make install" does not imply "make all install".
* Update Travis to build all the project, and install.
* CMake install with 'Optional': Specify that it is not an error if the file to be installed does not exist.