### PR TITLE
CMake: added tcc files when installing the project

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ install(
 	DESTINATION "include"
 	FILES_MATCHING
 	PATTERN "*.hpp"
+	PATTERN "*.tcc"
 	PATTERN "*.i"
 )
 install(TARGETS sequenceparser-static DESTINATION lib/ OPTIONAL)


### PR DESCRIPTION
These files are needed to compile cpp projects based on the sequenceParser.
